### PR TITLE
Revamp the logic for displaying the sharedEdit button

### DIFF
--- a/assets/javascripts/shared_edit_menu.js
+++ b/assets/javascripts/shared_edit_menu.js
@@ -6,9 +6,10 @@
 
     renderSharedEdit: function(post, buffer) {
       var current_user = Discourse.User.current();
-      if (!current_user || !current_user.staff || current_user.id != post.user_id) return;
-      // we only display the feature to the original author and admins
-      buffer.push("<button data-action=\"sharedEdit\" class='shared-edit'><i class=\"fa fa-users\"></i> <i class=\"fa fa-pencil\"></i></button>");
+      // we only display the feature to staff and the original author
+      if ((current_user && current_user.staff) || post.yours) {
+        buffer.push("<button data-action=\"sharedEdit\" class='shared-edit'><i class=\"fa fa-users\"></i> <i class=\"fa fa-pencil\"></i></button>");
+      }
     },
 
     clickSharedEdit: function() {


### PR DESCRIPTION
The problem before is that while staff members could see the button, the other
user who was supposed to be able to see it -- the post's original author, could
not. Now, we check if the user is an admin, or if the post in question is
theirs.

Closes #1
